### PR TITLE
FIX: Intellisense. Update tsconfig.json to match vite.config.ts

### DIFF
--- a/src/lib/polygon.test.ts
+++ b/src/lib/polygon.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect } from 'vitest';
-import { createPolygon, Polygon } from 'src/lib/polygon';
+import { createPolygon, Polygon } from '@/lib/polygon';
 
 type ContextWithPolygon = {
   polygon: Polygon;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "@/*": ["./*"],
+      "@/*": ["./src/*"],
       "$lib/*": ["./src/lib/*"],
       "$components/*": ["./src/components/*"],
       "test/*": ["./test/*"]


### PR DESCRIPTION
Vite is told the @ alias resolved to ./src
`'@': path.resolve(__dirname, './src')`
[while tsconfig.json is resolving to ./](https://github.com/stevekinney/enterprise-ui-dev/blob/ed365895722634c3a12209d566657200dee421b7/vite.config.ts#L10)
To allow intellisense to work correctly I've proposed tsconfig to change to match the same path so that intellisense will work correctly